### PR TITLE
Merge `badge-rockets` into development

### DIFF
--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -26,6 +26,15 @@ const ReserveButton = (props) => {
   }
   return <Button onClick={reserveRocket} variant="primary">Reserve Rocket</Button>;
 };
+
+const ReserveBadge = (props) => {
+  const { reserved } = props;
+
+  if (reserved) {
+    return <span><button type="button" className="rocket-reserve">Reserved</button></span>;
+  }
+  return <span />;
+};
 const Rocket = (props) => {
   const { rocket } = props;
 
@@ -55,7 +64,11 @@ const Rocket = (props) => {
         </Card.Body>
         <Card.Body className="rocket-info">
           <Card.Title>{rocketName}</Card.Title>
-          <Card.Text>{description}</Card.Text>
+          <Card.Text>
+            <ReserveBadge reserved={reserved} />
+            { ' ' }
+            {description}
+          </Card.Text>
           <ReserveButton
             reserved={reserved}
             reserveRocket={reserveUpdate}

--- a/src/css/rocket.css
+++ b/src/css/rocket.css
@@ -6,3 +6,12 @@
 .rocket-info {
   padding: 0 30px;
 }
+
+.rocket-reserve {
+  background-color: rgb(24, 162, 184);
+  color: white;
+  border: none;
+  border-radius: 5px;
+  padding: 0 5px;
+  font-size: 14px;
+}


### PR DESCRIPTION
- [x] Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)